### PR TITLE
add some flexibility to barcode specification

### DIFF
--- a/toulligqc/toulligqc.py
+++ b/toulligqc/toulligqc.py
@@ -313,7 +313,7 @@ def main():
             for b in config_dictionary['barcodes'].strip().split(','):
                 pattern = re.search(r'(BC|RB|NB|BARCODE)(\d{2})', b.strip().upper())
                 if pattern:
-                    barcode = 'barcode{}'.format(pattern.group(1))
+                    barcode = 'barcode{}'.format(pattern.group(2))
                     barcode_set.add(barcode)
             barcode_selection = sorted(barcode_set)
 


### PR DESCRIPTION
Appreciate the great tool for Nanopore QC!

I'm working with barcodes pulled from the [Native Barcode Kit](https://community.nanoporetech.com/protocols/native-barcoding-96-gdna/v/nbe_9121_v109_revb_19jan2021/equipment-and-consumables?devices=minion). Those barcodes have a different nomenclature than was supported out of the box. 

I added a slight modification to the regex to allow barcodes that look like some of the other names that the Nanopore kits use (could still make this more generic, but I tried to be true to the original) or allow the `barcode` prefix to be directly supplied. Just thought I'd contribute back here rather than just patch a local copy. 